### PR TITLE
Migrate Gateway to Spring Cloud Gateway, wire Kafka beans, add startup docs and fix compose ports

### DIFF
--- a/GatewayService/build.gradle
+++ b/GatewayService/build.gradle
@@ -15,6 +15,16 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.0")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -28,9 +38,7 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'

--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/GatewayServiceApplication.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/GatewayServiceApplication.java
@@ -2,10 +2,10 @@ package com.play.stream.Starjams.GatewayService;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
-@EnableZuulProxy
+@EnableDiscoveryClient
 public final class GatewayServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(GatewayServiceApplication.class, args);

--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/config/KafkaProducerConfig.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/config/KafkaProducerConfig.java
@@ -15,23 +15,22 @@ import java.util.Map;
 @Configuration
 public class KafkaProducerConfig {
 
-    @Value("${kafka.bootstrapServers}")
+    @Value("${kafka.bootstrapServers:127.0.0.1:9092}")
     private String bootstrapServers;
 
     @Bean
-    public ProducerFactory<String, String> producerFactory(){
+    public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> config = new HashMap<>();
 
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
-        return  new DefaultKafkaProducerFactory<>(config);
+        return new DefaultKafkaProducerFactory<>(config);
     }
 
     @Bean
     public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
-
 }

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.mail.host=smtp.sendgrid.net
 spring.mail.port=587
 spring.mail.username=apikey
 spring.mail.password=SG.yourSendGridApiKey
+
+# Kafka Configuration
+kafka.bootstrapServers=127.0.0.1:9092

--- a/README.md
+++ b/README.md
@@ -48,3 +48,30 @@ Starjamz is designed to go far beyond a typical music streaming service.
 
 ## Architecture
 Starjamz employs an architecture based on microservices that run, and can be scaled, independently of each other. 
+
+## Getting the app running locally
+
+Right now, the repo is **not a one-command startup**. To run it successfully, you need to provide missing infrastructure and a few config fixes.
+
+### 1) Use Java 17 for all Gradle builds
+All services target Java 17, so use JDK 17 when running Gradle.
+
+### 2) Bring up required infrastructure first
+The services are configured to expect these dependencies:
+- **Eureka server** at `http://localhost:8761/eureka/`
+- **Kafka** broker at `127.0.0.1:9092`
+- **Redis** at `localhost:6379`
+
+### 3) Set real secrets (or disable integrations while developing)
+Default properties use placeholder values for Stripe and SendGrid. Replace them before testing payment/email flows.
+
+### 4) Start backend services
+You can start each service with Gradle from its folder (`GatewayService`, `PaymentService`, `MusicService`, etc.).
+
+### 5) Start frontend
+From `Frontend/starjamz`, install dependencies and run the Next.js app.
+
+### Known repository gaps
+- No Eureka server service/module is included in this repository.
+- The docker compose file is for backend services only and does not include Eureka/Kafka/Redis.
+- Gateway routes are discovery-driven, so service registration needs to be working before gateway endpoints resolve.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,4 @@ services:
   like-service:
     build: ./LikeService
     ports:
-      - "8085:8080"   
+      - "8086:8080"   


### PR DESCRIPTION
### Motivation
- Replace the deprecated Zuul proxy with a supported Spring Cloud Gateway to align the gateway with Spring Boot 3 and Spring Cloud.
- Move Kafka producer construction into Spring-managed beans so lifecycle, configuration, and injection are correct and configurable.
- Document the external infrastructure and local startup steps because the repository requires services (Eureka, Kafka, Redis) that are not included.
- Fix a docker-compose host-port collision that prevented both services from being exposed simultaneously.

### Description
- Add Spring Cloud BOM import and set `springCloudVersion`, and replace the Zuul dependency with `spring-cloud-starter-gateway` in `GatewayService/build.gradle`.
- Replace `@EnableZuulProxy` with `@EnableDiscoveryClient` in `GatewayServiceApplication` so the app uses discovery-driven gateway behavior.
- Refactor `KafkaPublisherService` to accept a Spring-injected `KafkaTemplate<String,String>` and `ObjectMapper` and publish with `kafkaTemplate.send(...)` instead of manually creating a `KafkaProducer`.
- Update `KafkaProducerConfig` to read `kafka.bootstrapServers` from properties with a `127.0.0.1:9092` default and add that property to `GatewayService/src/main/resources/application.properties`.
- Add a `Getting the app running locally` section to the root `README.md` with JDK, infra, and startup instructions and adjust `docker-compose.yml` to move `like-service` host port from `8085` to `8086` to avoid collisions.

### Testing
- Verified docker-compose host-port uniqueness with `awk '/- "[0-9]+:8080"/{gsub(/"/ ,"",$2); split($2,a,":"); print a[1]}' docker-compose.yml | sort | uniq -d` which returned no duplicates.
- Attempted to run `./gradlew test` but automated Gradle test runs could not complete in this environment due to external download/plugin resolution being blocked and local JDK/Gradle version mismatches, so no service unit tests were executed here.
- No additional automated tests failed as part of these changes in this environment due to the infrastructure and tooling limitations described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c68254f5083309655de6179fbfbd6)