### PR TITLE
Wire GatewayService routes to microservices, refactor Kafka wiring, add configs and docs

### DIFF
--- a/AdminService/application.yml
+++ b/AdminService/application.yml
@@ -2,14 +2,9 @@ server:
   port: 8080
 
 spring:
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+  application:
+    name: admin-service
+
 eureka:
   client:
     serviceUrl:

--- a/FeedService/application.yml
+++ b/FeedService/application.yml
@@ -2,14 +2,9 @@ server:
   port: 8080
 
 spring:
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+  application:
+    name: feed-service
+
 eureka:
   client:
     serviceUrl:

--- a/GatewayService/application.yml
+++ b/GatewayService/application.yml
@@ -2,14 +2,56 @@ server:
   port: 8080
 
 spring:
+  application:
+    name: gateway-service
   cloud:
     gateway:
       discovery:
         locator:
           enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+          lower-case-service-id: true
+      routes:
+        - id: payment-service
+          uri: lb://payment-service
+          predicates:
+            - Path=/payment/**
+          filters:
+            - StripPrefix=1
+        - id: music-service
+          uri: lb://music-service
+          predicates:
+            - Path=/music/**
+          filters:
+            - StripPrefix=1
+        - id: admin-service
+          uri: lb://admin-service
+          predicates:
+            - Path=/admin/**
+          filters:
+            - StripPrefix=1
+        - id: user-service
+          uri: lb://user-service
+          predicates:
+            - Path=/user/**
+          filters:
+            - StripPrefix=1
+        - id: feed-service
+          uri: lb://feed-service
+          predicates:
+            - Path=/feed/**
+          filters:
+            - StripPrefix=1
+        - id: like-service
+          uri: lb://like-service
+          predicates:
+            - Path=/like/**
+          filters:
+            - StripPrefix=1
+
+  loadbalancer:
+    ribbon:
+      enabled: false
+
 eureka:
   client:
     serviceUrl:

--- a/GatewayService/build.gradle
+++ b/GatewayService/build.gradle
@@ -15,6 +15,16 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.0")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -28,9 +38,7 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'

--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/GatewayServiceApplication.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/GatewayServiceApplication.java
@@ -2,10 +2,10 @@ package com.play.stream.Starjams.GatewayService;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
-@EnableZuulProxy
+@EnableDiscoveryClient
 public final class GatewayServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(GatewayServiceApplication.class, args);

--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/config/KafkaProducerConfig.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/config/KafkaProducerConfig.java
@@ -15,23 +15,22 @@ import java.util.Map;
 @Configuration
 public class KafkaProducerConfig {
 
-    @Value("${kafka.bootstrapServers}")
+    @Value("${kafka.bootstrapServers:127.0.0.1:9092}")
     private String bootstrapServers;
 
     @Bean
-    public ProducerFactory<String, String> producerFactory(){
+    public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> config = new HashMap<>();
 
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
-        return  new DefaultKafkaProducerFactory<>(config);
+        return new DefaultKafkaProducerFactory<>(config);
     }
 
     @Bean
     public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
-
 }

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.mail.host=smtp.sendgrid.net
 spring.mail.port=587
 spring.mail.username=apikey
 spring.mail.password=SG.yourSendGridApiKey
+
+# Kafka Configuration
+kafka.bootstrapServers=127.0.0.1:9092

--- a/LikeService/application.yml
+++ b/LikeService/application.yml
@@ -2,12 +2,10 @@ server:
   port: 8080
 
 spring:
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+  application:
+    name: like-service
 
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/

--- a/MusicService/application.yml
+++ b/MusicService/application.yml
@@ -2,14 +2,9 @@ server:
   port: 8080
 
 spring:
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+  application:
+    name: music-service
+
 eureka:
   client:
     serviceUrl:

--- a/PaymentService/application.yml
+++ b/PaymentService/application.yml
@@ -2,14 +2,9 @@ server:
   port: 8080
 
 spring:
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+  application:
+    name: payment-service
+
 eureka:
   client:
     serviceUrl:

--- a/README.md
+++ b/README.md
@@ -48,3 +48,30 @@ Starjamz is designed to go far beyond a typical music streaming service.
 
 ## Architecture
 Starjamz employs an architecture based on microservices that run, and can be scaled, independently of each other. 
+
+## Getting the app running locally
+
+Right now, the repo is **not a one-command startup**. To run it successfully, you need to provide missing infrastructure and a few config fixes.
+
+### 1) Use Java 17 for all Gradle builds
+All services target Java 17, so use JDK 17 when running Gradle.
+
+### 2) Bring up required infrastructure first
+The services are configured to expect these dependencies:
+- **Eureka server** at `http://localhost:8761/eureka/`
+- **Kafka** broker at `127.0.0.1:9092`
+- **Redis** at `localhost:6379`
+
+### 3) Set real secrets (or disable integrations while developing)
+Default properties use placeholder values for Stripe and SendGrid. Replace them before testing payment/email flows.
+
+### 4) Start backend services
+You can start each service with Gradle from its folder (`GatewayService`, `PaymentService`, `MusicService`, etc.).
+
+### 5) Start frontend
+From `Frontend/starjamz`, install dependencies and run the Next.js app.
+
+### Known repository gaps
+- No Eureka server service/module is included in this repository.
+- The docker compose file is for backend services only and does not include Eureka/Kafka/Redis.
+- Gateway routes are discovery-driven, so service registration needs to be working before gateway endpoints resolve.

--- a/UserService/application.yml
+++ b/UserService/application.yml
@@ -2,14 +2,9 @@ server:
   port: 8080
 
 spring:
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-    loadbalancer:
-      ribbon:
-        enabled: false
+  application:
+    name: user-service
+
 eureka:
   client:
     serviceUrl:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,4 @@ services:
   like-service:
     build: ./LikeService
     ports:
-      - "8085:8080"   
+      - "8086:8080"   


### PR DESCRIPTION
### Motivation
- Ensure the GatewayService forwards requests to backend services using Eureka discovery and stable service IDs so the gateway actually reaches each microservice. 
- Move Kafka producer usage to Spring-managed beans and make bootstrap servers configurable for correct lifecycle and injection. 
- Provide minimal local-run guidance and fix a docker-compose port collision to improve developer experience.

### Description
- Added explicit `spring.application.name` entries for `GatewayService`, `PaymentService`, `MusicService`, `AdminService`, `UserService`, `FeedService`, and `LikeService` so services register with stable Eureka IDs. 
- Added concrete Spring Cloud Gateway routes in `GatewayService/application.yml` mapping path prefixes to `lb://<service-name>` URIs and enabled `lower-case-service-id` for discovery locator. 
- Replaced deprecated Zuul enablement with `@EnableDiscoveryClient` in `GatewayServiceApplication` and added Spring Cloud Gateway dependency and BOM to `GatewayService/build.gradle`. 
- Refactored Kafka code to use a Spring `KafkaTemplate<String,String>` and injected `ObjectMapper`, added `KafkaProducerConfig` that reads `kafka.bootstrapServers` (default `127.0.0.1:9092`), and added that property to `GatewayService/src/main/resources/application.properties`. 
- Cleaned non-gateway YAML files by removing misplaced gateway config and kept only service identity + Eureka client config. 
- Updated `README.md` with local-run notes and adjusted `docker-compose.yml` to move `like-service` host port from `8085` to `8086` to avoid collisions.

### Testing
- Verified presence of service names and gateway route config by running `for f in GatewayService/application.yml PaymentService/application.yml MusicService/application.yml AdminService/application.yml UserService/application.yml FeedService/application.yml LikeService/application.yml; do rg -n "name:|defaultZone|routes:|Path=/" $f; done`, which returned expected entries. 
- Inspected updated YAML contents with `nl -ba <file>` to confirm route and service-name lines were added as intended. 
- Attempted to run `./gradlew test` but full Gradle test execution could not complete in this environment due to external dependency/plugin resolution restrictions, so unit/integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c68254f5083309655de6179fbfbd6)