### PR TITLE
Add playlist gateway endpoints and WebFlux security to GatewayService

### DIFF
--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/config/SecurityConfig.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.play.stream.Starjams.GatewayService.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchange -> exchange
+                        .anyExchange().permitAll())
+                .build();
+    }
+}

--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/controllers/PlaylistGatewayController.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/controllers/PlaylistGatewayController.java
@@ -1,0 +1,34 @@
+package com.play.stream.Starjams.GatewayService.controllers;
+
+import com.play.stream.Starjams.GatewayService.services.GatewayService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/gateway/playlists")
+public class PlaylistGatewayController {
+
+    private final GatewayService gatewayService;
+
+    public PlaylistGatewayController(GatewayService gatewayService) {
+        this.gatewayService = gatewayService;
+    }
+
+    @GetMapping
+    public ResponseEntity<String> getAllPlaylists() {
+        return ResponseEntity.ok(gatewayService.getAllPlaylists());
+    }
+
+    @GetMapping("/{playlistId}")
+    public ResponseEntity<String> getPlaylistById(@PathVariable String playlistId) {
+        return ResponseEntity.ok(gatewayService.getPlaylistById(playlistId));
+    }
+
+    @PostMapping
+    public ResponseEntity<String> createPlaylist(@RequestBody Map<String, Object> payload) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(gatewayService.createPlaylist(payload));
+    }
+}

--- a/GatewayService/src/test/java/com/play/stream/Starjams/GatewayService/controllers/PlaylistGatewayControllerTest.java
+++ b/GatewayService/src/test/java/com/play/stream/Starjams/GatewayService/controllers/PlaylistGatewayControllerTest.java
@@ -1,0 +1,60 @@
+package com.play.stream.Starjams.GatewayService.controllers;
+
+import com.play.stream.Starjams.GatewayService.services.GatewayService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@WebFluxTest(controllers = PlaylistGatewayController.class)
+class PlaylistGatewayControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private GatewayService gatewayService;
+
+    @Test
+    void shouldReturnAllPlaylists() {
+        when(gatewayService.getAllPlaylists()).thenReturn("[{\"id\":\"pl-1\"}]");
+
+        webTestClient.get()
+                .uri("/gateway/playlists")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo("[{\"id\":\"pl-1\"}]");
+    }
+
+    @Test
+    void shouldReturnPlaylistById() {
+        when(gatewayService.getPlaylistById(eq("pl-9"))).thenReturn("{\"id\":\"pl-9\"}");
+
+        webTestClient.get()
+                .uri("/gateway/playlists/pl-9")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo("{\"id\":\"pl-9\"}");
+    }
+
+    @Test
+    void shouldCreatePlaylist() {
+        when(gatewayService.createPlaylist(anyMap())).thenReturn("{\"id\":\"new\"}");
+
+        webTestClient.post()
+                .uri("/gateway/playlists")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("name", "Workout"))
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(String.class).isEqualTo("{\"id\":\"new\"}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose playlist operations from the Gateway so external clients and internal services can call playlist-related APIs through the gateway boundary.
- Ensure the gateway does not block requests with default Spring Security behavior by providing a minimal reactive security policy appropriate for an API gateway.
- Provide focused controller tests so the new endpoints have quick unit coverage and a safety net for future refactors.

### Description
- Added `PlaylistGatewayController` with three endpoints: `GET /gateway/playlists`, `GET /gateway/playlists/{playlistId}`, and `POST /gateway/playlists`, delegating to the existing `GatewayService` methods (`GatewayService.getAllPlaylists`, `getPlaylistById`, `createPlaylist`).
- Added reactive `SecurityConfig` that disables CSRF and permits all exchanges to allow gateway traffic without interactive login barriers.
- Added `PlaylistGatewayControllerTest` (`@WebFluxTest`) that mocks `GatewayService` and verifies the three endpoints return the expected HTTP status and body.

### Testing
- Added unit tests under `GatewayService/src/test/java/.../PlaylistGatewayControllerTest.java` that run as `@WebFluxTest` and validate the controller behavior (tests present but not executed in CI here).
- Attempted to run tests locally with `cd GatewayService && JAVA_HOME=$HOME/.local/share/mise/installs/java/17.0.2 PATH=$JAVA_HOME/bin:$PATH gradle test --no-daemon` which failed because the Gradle build could not resolve the `org.springframework.boot:org.springframework.boot.gradle.plugin:3.2.2` plugin from the Gradle Plugin Repository in this environment.
- Java selection was validated by switching to Java 17 for the test run (`java -version` showed OpenJDK 17 when `JAVA_HOME` was set), but plugin resolution/network access prevented completing the `gradle test` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8b336f608330980f9613c6779252)