### PR TITLE
Gateway: proxy all core downstream services via /gateway/{service}/**

### DIFF
--- a/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/services/GatewayService.java
+++ b/GatewayService/src/main/java/com/play/stream/Starjams/GatewayService/services/GatewayService.java
@@ -1,49 +1,88 @@
 package com.play.stream.Starjams.GatewayService.services;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 
 @Service
 public class GatewayService {
 
-    private final WebClient webClient;
+    private final WebClient.Builder webClientBuilder;
+    private final Map<String, String> serviceBaseUrls;
 
     public GatewayService(
             WebClient.Builder webClientBuilder,
-            @Value("${playlist.service.base-url:lb://playlist-service}") String playlistServiceBaseUrl) {
-        this.webClient = webClientBuilder.baseUrl(playlistServiceBaseUrl).build();
+            @Value("${admin.service.base-url:lb://admin-service}") String adminServiceBaseUrl,
+            @Value("${feed.service.base-url:lb://feed-service}") String feedServiceBaseUrl,
+            @Value("${like.service.base-url:lb://like-service}") String likeServiceBaseUrl,
+            @Value("${music.service.base-url:lb://music-service}") String musicServiceBaseUrl,
+            @Value("${payment.service.base-url:lb://payment-service}") String paymentServiceBaseUrl,
+            @Value("${playlist.service.base-url:lb://playlist-service}") String playlistServiceBaseUrl,
+            @Value("${user.service.base-url:lb://user-service}") String userServiceBaseUrl) {
+        this.webClientBuilder = webClientBuilder;
+        this.serviceBaseUrls = new HashMap<>();
+        this.serviceBaseUrls.put("admin", adminServiceBaseUrl);
+        this.serviceBaseUrls.put("feed", feedServiceBaseUrl);
+        this.serviceBaseUrls.put("like", likeServiceBaseUrl);
+        this.serviceBaseUrls.put("music", musicServiceBaseUrl);
+        this.serviceBaseUrls.put("payment", paymentServiceBaseUrl);
+        this.serviceBaseUrls.put("playlist", playlistServiceBaseUrl);
+        this.serviceBaseUrls.put("user", userServiceBaseUrl);
     }
 
-    public String getPlaylistById(String playlistId) {
-        return webClient
-                .get()
-                .uri("/playlists/{playlistId}", playlistId)
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
-    }
+    public ResponseEntity<String> proxyRequest(
+            String service,
+            HttpMethod httpMethod,
+            String path,
+            String query,
+            HttpHeaders headers,
+            String body) {
+        String serviceBaseUrl = serviceBaseUrls.get(service.toLowerCase());
+        if (serviceBaseUrl == null) {
+            return ResponseEntity.badRequest().body("Unsupported service: " + service);
+        }
 
-    public String getAllPlaylists() {
-        return webClient
-                .get()
-                .uri("/playlists")
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
-    }
+        URI targetUri = UriComponentsBuilder
+                .fromUriString(serviceBaseUrl)
+                .path(path)
+                .query(query)
+                .build(true)
+                .toUri();
 
-    public String createPlaylist(Map<String, Object> payload) {
-        return webClient
-                .post()
-                .uri("/playlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(payload)
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
+        WebClient.RequestBodySpec requestSpec = webClientBuilder
+                .build()
+                .method(httpMethod)
+                .uri(targetUri)
+                .headers(httpHeaders -> {
+                    httpHeaders.addAll(headers);
+                    httpHeaders.remove(HttpHeaders.HOST);
+                    httpHeaders.remove(HttpHeaders.CONTENT_LENGTH);
+                });
+
+        WebClient.RequestHeadersSpec<?> requestHeadersSpec = body != null && !body.isBlank()
+                ? requestSpec.contentType(MediaType.APPLICATION_JSON).bodyValue(body)
+                : requestSpec;
+
+        try {
+            return requestHeadersSpec
+                    .retrieve()
+                    .toEntity(String.class)
+                    .block();
+        } catch (WebClientResponseException exception) {
+            return ResponseEntity
+                    .status(exception.getStatusCode())
+                    .headers(exception.getHeaders())
+                    .body(exception.getResponseBodyAsString());
+        }
     }
 }

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -14,5 +14,11 @@ spring.mail.password=SG.yourSendGridApiKey
 # Kafka Configuration
 kafka.bootstrapServers=127.0.0.1:9092
 
-# Playlist Service
+# Downstream Service Base URLs
+admin.service.base-url=lb://admin-service
+feed.service.base-url=lb://feed-service
+like.service.base-url=lb://like-service
+music.service.base-url=lb://music-service
+payment.service.base-url=lb://payment-service
 playlist.service.base-url=lb://playlist-service
+user.service.base-url=lb://user-service


### PR DESCRIPTION
### Motivation
- Ensure all downstream services are only reachable through the gateway so the gateway is the single access point for downstream microservices. 
- Replace playlist-specific proxy logic with a generic routing layer that can handle multiple service backends.

### Description
- Replaced playlist-specific endpoints with a generic controller that accepts `GET/POST/PUT/PATCH/DELETE` at `/gateway/{service}/**` and extracts path, query, headers, and optional body to forward to the gateway service. 
- Implemented a generic `GatewayService.proxyRequest(...)` that resolves service base URLs from configuration, builds a target URI, forwards the request using `WebClient.Builder`, and returns the downstream `ResponseEntity<String>` including error status/body when a `WebClientResponseException` occurs. 
- Added configurable base URLs for each supported downstream service (`admin`, `feed`, `like`, `music`, `payment`, `playlist`, `user`) in `GatewayService/src/main/resources/application.properties`. 
- Preserved and forwarded incoming request headers except `Host` and `Content-Length`, and use a load-balanced `WebClient.Builder` to resolve `lb://` service addresses.

### Testing
- Ran `cd GatewayService && mvn test` which failed because this module is Gradle-based and there is no `pom.xml` in the directory. (failed)
- Attempted `cd GatewayService && ./gradlew test` which could not execute due to `Permission denied` on the wrapper script. (failed)
- Ran `cd GatewayService && gradle test` which failed in this environment with `Unsupported class file major version 69` due to a JDK/Gradle compatibility issue. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de0923c24833085b6df8f4946f5c0)