### PR TITLE
Upgrade all microservices to Spring Boot 3.5.11 and Java 21

### DIFF
--- a/AdminService/build.gradle
+++ b/AdminService/build.gradle
@@ -1,18 +1,30 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 dependencies {
@@ -28,9 +40,6 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'
@@ -43,7 +52,6 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java
 	implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.10.2'
-
 }
 
 tasks.named('test') {

--- a/FeedService/build.gradle
+++ b/FeedService/build.gradle
@@ -1,18 +1,30 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 dependencies {
@@ -28,9 +40,6 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'
@@ -43,7 +52,6 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java
 	implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.10.2'
-
 }
 
 tasks.named('test') {

--- a/GatewayService/build.gradle
+++ b/GatewayService/build.gradle
@@ -1,14 +1,16 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
@@ -16,7 +18,7 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "2023.0.0")
+	set('springCloudVersion', "2025.0.1")
 }
 
 dependencyManagement {
@@ -54,8 +56,6 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka
 	implementation group: 'org.springframework.kafka', name: 'spring-kafka', version: '3.1.2'
-
-
 }
 
 tasks.named('test') {

--- a/LikeService/build.gradle
+++ b/LikeService/build.gradle
@@ -1,18 +1,30 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 dependencies {
@@ -28,9 +40,6 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'
@@ -43,7 +52,6 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java
 	implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.10.2'
-
 }
 
 tasks.named('test') {

--- a/MediaService/build.gradle
+++ b/MediaService/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play'
@@ -10,7 +10,7 @@ description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 

--- a/MusicService/build.gradle
+++ b/MusicService/build.gradle
@@ -1,18 +1,30 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 dependencies {
@@ -28,9 +40,6 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'

--- a/PaymentService/build.gradle
+++ b/PaymentService/build.gradle
@@ -1,18 +1,30 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 dependencies {
@@ -28,9 +40,6 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'
@@ -43,7 +52,6 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java
 	implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.10.2'
-
 }
 
 tasks.named('test') {

--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -1,18 +1,30 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.play.stream'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 }
 
 repositories {
 	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 dependencies {
@@ -28,9 +40,6 @@ dependencies {
 	implementation 'com.datastax.oss:java-driver-core:4.13.0'
 	implementation 'com.datastax.astra:astra-spring-boot-starter:0.1.13'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	
-	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-zuul
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.2.10.RELEASE'
 
 	// https://mvnrepository.com/artifact/org.springframework.data/spring-data-cassandra
 	implementation group: 'org.springframework.data', name: 'spring-data-cassandra', version: '4.2.3'
@@ -46,7 +55,6 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.datastax.oss/java-driver-core
 	implementation group: 'com.datastax.oss', name: 'java-driver-core', version: '4.17.0'
-
 }
 
 tasks.named('test') {


### PR DESCRIPTION
- Spring Boot: 3.2.2 → 3.5.11 across all 8 services
- dependency-management plugin: 1.1.4 → 1.1.7
- Java toolchain: 17 → 21 (switched sourceCompatibility to toolchain block)
- Spring Cloud BOM: 2023.0.0 → 2025.0.1 (compatible with Spring Boot 3.5.x)
- Added Spring Cloud BOM to AdminService, FeedService, LikeService, MusicService, PaymentService, and UserService (previously missing)
- Removed EOL spring-cloud-starter-netflix-zuul from all services (Zuul was removed from Spring Cloud years ago)

https://claude.ai/code/session_01DgeFvBcezazzwXUuf4xjhn