### PR TITLE
Set Gradle JVM to Java 21 via gradle.properties

### DIFF
--- a/MediaService/gradle.properties
+++ b/MediaService/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=/usr/lib/jvm/java-1.21.0-openjdk-amd64


### PR DESCRIPTION
Spring Boot 3.x and Gradle 8.x both require Java 17+ to run the Gradle daemon. The build was failing because the default JVM was Java 8. Points org.gradle.java.home at the system Java 21 installation.

https://claude.ai/code/session_01DgeFvBcezazzwXUuf4xjhn