### PR TITLE
Add Dockerfiles for all services and wire everything into Compose

### DIFF
--- a/AdminService/Dockerfile
+++ b/AdminService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/FeedService/Dockerfile
+++ b/FeedService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Frontend/starjamz/Dockerfile
+++ b/Frontend/starjamz/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/Frontend/starjamz/next.config.mjs
+++ b/Frontend/starjamz/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'standalone',
 };
 
 export default nextConfig;

--- a/GatewayService/Dockerfile
+++ b/GatewayService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/LikeService/Dockerfile
+++ b/LikeService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/MusicService/Dockerfile
+++ b/MusicService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/PaymentService/Dockerfile
+++ b/PaymentService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/UploadService/Dockerfile
+++ b/UploadService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/UserService/Dockerfile
+++ b/UserService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       scylla-init:
         condition: service_completed_successfully
 
+  # ── Frontend ──────────────────────────────────────────────────────────────────
+  frontend:
+    build: ./Frontend/starjamz
+    ports:
+      - "3000:3000"
+
   # ── ScyllaDB ─────────────────────────────────────────────────────────────────
   scylla:
     image: scylladb/scylla:5.4


### PR DESCRIPTION
- GatewayService, PaymentService, MusicService, AdminService, UserService, FeedService, LikeService, UploadService: identical two-stage Dockerfile using gradle:8-jdk21-alpine to build and eclipse-temurin:21-jre-alpine to run (no gradlew dependency)
- Frontend/starjamz: three-stage Next.js Dockerfile (deps → builder → runner) using node:20-alpine; runner stage only copies the standalone output for a lean image
- Frontend/starjamz/next.config.mjs: enable output: 'standalone' so the standalone build artifact is produced for the Docker runner stage
- docker-compose.yml: add frontend service on port 3000; all 9 services
  + ScyllaDB are now startable with a single `docker compose up --build`

https://claude.ai/code/session_01DgeFvBcezazzwXUuf4xjhn