### PR TITLE
Claude/starjamz bug audit 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.

--- a/FeedService/src/main/java/com/play/stream/Starjams/FeedService/services/FeedReadService.java
+++ b/FeedService/src/main/java/com/play/stream/Starjams/FeedService/services/FeedReadService.java
@@ -12,6 +12,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Reads a user's personal feed from Aerospike, merges in popular/trending content
@@ -245,10 +247,72 @@ public class FeedReadService {
 
         // Fetch top trending track IDs from Aerospike (already scored)
         List<String> trendingIds = trending.getTopTrendingTracks("24h", null, popularSlots);
-        // In a full implementation, trending track metadata would be fetched from
-        // PostgreSQL or Redis and converted to FeedEvents here.
-        // For now, popular injection is proportionally reserved in the result.
-        return ranked; // TODO: merge popular FeedEvents into result
+        if (trendingIds.isEmpty()) return ranked;
+
+        // Build a set of trackIds already present in the personal feed to avoid duplicates
+        Set<String> existingTrackIds = new HashSet<>();
+        for (FeedEvent ev : ranked) {
+            if (ev.getTrackId() != null) existingTrackIds.add(ev.getTrackId().toString());
+        }
+
+        // Construct synthetic FeedEvents for trending tracks not already in the feed
+        List<FeedEvent> popularEvents = new ArrayList<>();
+        for (String trackId : trendingIds) {
+            if (existingTrackIds.contains(trackId)) continue;
+            if (popularEvents.size() >= popularSlots) break;
+
+            FeedEvent popular = new FeedEvent();
+            popular.setEventId(UUID.randomUUID());
+            popular.setEventType(EventType.TRACK_POSTED);
+            popular.setPostedAt(Instant.now());
+            try {
+                popular.setTrackId(UUID.fromString(trackId));
+            } catch (IllegalArgumentException ignored) {
+                continue; // skip malformed IDs
+            }
+
+            // Hydrate real-time counters from Aerospike track_stats
+            Key statsKey = new Key(NS, "track_stats:" + trackId, trackId);
+            Record stats = aerospike.get(null, statsKey,
+                "playCount", "likeCount", "repostCount", "commentCount", "isBuzzing");
+            if (stats != null) {
+                popular.setPlayCount(stats.getLong("playCount"));
+                popular.setLikeCount(stats.getLong("likeCount"));
+                popular.setRepostCount(stats.getLong("repostCount"));
+                popular.setCommentCount(stats.getLong("commentCount"));
+                popular.setBuzzing(stats.getLong("isBuzzing") == 1);
+            }
+
+            // Assign a rank score slightly below the lowest personal-feed item
+            // so popular content fills gaps but personal content ranks higher
+            double baseScore = ranked.isEmpty() ? 0.0 : ranked.get(ranked.size() - 1).getRankScore();
+            popular.setRankScore(baseScore - (0.01 * (popularEvents.size() + 1)));
+
+            popularEvents.add(popular);
+            existingTrackIds.add(trackId);
+        }
+
+        if (popularEvents.isEmpty()) return ranked;
+
+        // Interleave popular events: insert one popular item every N personal items
+        // where N = floor(personalSlots / popularSlots), minimum 1
+        int personalSlots = targetSize - popularEvents.size();
+        int stride = personalSlots > 0 ? Math.max(1, personalSlots / popularEvents.size()) : 1;
+
+        List<FeedEvent> blended = new ArrayList<>(ranked.size() + popularEvents.size());
+        int popularIdx = 0;
+        for (int i = 0; i < ranked.size(); i++) {
+            blended.add(ranked.get(i));
+            if (popularIdx < popularEvents.size() && (i + 1) % stride == 0) {
+                blended.add(popularEvents.get(popularIdx++));
+            }
+        }
+        // Append any remaining popular events not yet inserted
+        while (popularIdx < popularEvents.size()) {
+            blended.add(popularEvents.get(popularIdx++));
+        }
+
+        return blended;
     }
 
     // -------------------------------------------------------------------------

--- a/MusicService/src/main/java/com/play/stream/Starjams/MusicService/services/StemSessionService.java
+++ b/MusicService/src/main/java/com/play/stream/Starjams/MusicService/services/StemSessionService.java
@@ -4,6 +4,7 @@ import com.aerospike.client.Bin;
 import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
+import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -195,9 +196,57 @@ public class StemSessionService {
     @Scheduled(fixedRateString = "${stem.royalty.flush.interval.ms:3600000}")
     public void flushRoyaltiesToPostgres() {
         log.info("Starting hourly royalty flush to PostgreSQL");
-        // This hook is wired; real implementation would scan Aerospike set
-        // and batch-insert into stem_royalty_ledger via royaltyRepo.
-        // Kept as a scheduled placeholder matching the architecture spec.
+        try {
+            List<Map.Entry<Key, Record>> pending = new ArrayList<>();
+
+            ScanPolicy sp = new ScanPolicy();
+            aerospike.scanAll(sp, NS, ROYALTY_SET, (key, record) -> {
+                if (record != null) {
+                    pending.add(Map.entry(key, record));
+                }
+            });
+
+            if (pending.isEmpty()) {
+                log.info("Royalty flush: no pending records found");
+                return;
+            }
+
+            List<StemRoyaltyLedger> ledgerEntries = new ArrayList<>(pending.size());
+            for (Map.Entry<Key, Record> entry : pending) {
+                Record rec = entry.getValue();
+                try {
+                    UUID sessionId      = UUID.fromString(rec.getString("sessionId"));
+                    UUID hostUserId     = UUID.fromString(rec.getString("hostUserId"));
+                    UUID listenerUserId = UUID.fromString(rec.getString("listenerUserId"));
+                    double minutes      = rec.getDouble("listenerMinutes");
+
+                    BigDecimal listenerMinutes = BigDecimal.valueOf(minutes);
+                    BigDecimal royaltyAmount   = BigDecimal.valueOf(minutes * ROYALTY_PER_LISTENER_MINUTE);
+
+                    ledgerEntries.add(new StemRoyaltyLedger(
+                        sessionId, hostUserId, listenerUserId, listenerMinutes, royaltyAmount));
+                } catch (Exception e) {
+                    log.warn("Skipping malformed royalty record key={}: {}", entry.getKey(), e.getMessage());
+                }
+            }
+
+            royaltyRepo.saveAll(ledgerEntries);
+            log.info("Royalty flush: persisted {} records to PostgreSQL", ledgerEntries.size());
+
+            // Delete flushed records from Aerospike (at-least-once: only after successful save)
+            for (Map.Entry<Key, Record> entry : pending) {
+                try {
+                    aerospike.delete(null, entry.getKey());
+                } catch (Exception e) {
+                    log.warn("Failed to delete flushed royalty record key={}: {}", entry.getKey(), e.getMessage());
+                }
+            }
+
+            log.info("Royalty flush: removed {} records from Aerospike", pending.size());
+
+        } catch (Exception e) {
+            log.error("Royalty flush failed — records left intact in Aerospike for next run: {}", e.getMessage(), e);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/NotificationService/src/main/java/com/play/stream/Starjams/NotificationService/config/FirebaseConfig.java
+++ b/NotificationService/src/main/java/com/play/stream/Starjams/NotificationService/config/FirebaseConfig.java
@@ -1,0 +1,61 @@
+package com.play.stream.Starjams.NotificationService.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Initialises Firebase Admin SDK from a service-account credentials file.
+ *
+ * <p>If {@code firebase.credentials-path} is blank or the file is missing,
+ * the bean is skipped and FCM push delivery is silently disabled — the
+ * service still starts and handles all other notification flows.
+ */
+@Configuration
+public class FirebaseConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(FirebaseConfig.class);
+
+    @Value("${firebase.credentials-path:}")
+    private String credentialsPath;
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        if (credentialsPath == null || credentialsPath.isBlank()) {
+            log.warn("firebase.credentials-path is not set — FCM push delivery disabled");
+            return null;
+        }
+
+        try (InputStream stream = new FileInputStream(credentialsPath)) {
+            GoogleCredentials credentials = GoogleCredentials.fromStream(stream);
+            FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .build();
+
+            FirebaseApp app;
+            if (FirebaseApp.getApps().isEmpty()) {
+                app = FirebaseApp.initializeApp(options);
+            } else {
+                app = FirebaseApp.getInstance();
+            }
+
+            log.info("Firebase Admin SDK initialised successfully");
+            return FirebaseMessaging.getInstance(app);
+
+        } catch (IOException e) {
+            log.warn("Could not load Firebase credentials from '{}' — FCM push delivery disabled: {}",
+                credentialsPath, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/NotificationService/src/main/java/com/play/stream/Starjams/NotificationService/service/NotificationDeliveryService.java
+++ b/NotificationService/src/main/java/com/play/stream/Starjams/NotificationService/service/NotificationDeliveryService.java
@@ -2,15 +2,23 @@ package com.play.stream.Starjams.NotificationService.service;
 
 import com.aerospike.client.*;
 import com.aerospike.client.policy.WritePolicy;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import com.play.stream.Starjams.NotificationService.entity.UserNotification;
 import com.play.stream.Starjams.NotificationService.model.NotificationEvent;
 import com.play.stream.Starjams.NotificationService.repository.UserNotificationRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Core notification delivery logic:
@@ -34,10 +42,15 @@ public class NotificationDeliveryService {
     private final IAerospikeClient aerospike;
     private final UserNotificationRepository notifRepo;
 
+    @Nullable
+    private final FirebaseMessaging firebaseMessaging;
+
     public NotificationDeliveryService(IAerospikeClient aerospike,
-                                       UserNotificationRepository notifRepo) {
-        this.aerospike  = aerospike;
-        this.notifRepo  = notifRepo;
+                                       UserNotificationRepository notifRepo,
+                                       @Autowired(required = false) FirebaseMessaging firebaseMessaging) {
+        this.aerospike         = aerospike;
+        this.notifRepo         = notifRepo;
+        this.firebaseMessaging = firebaseMessaging;
     }
 
     /**
@@ -66,10 +79,56 @@ public class NotificationDeliveryService {
             recordDedupKey(event);
         }
 
-        // 5. Send push notification
-        // FCM dispatch would happen here.
-        // Implementation depends on the firebase-admin SDK setup and device token lookup.
-        log.info("Push notification delivered to {} — type={}", event.getRecipientId(), event.getType());
+        // 5. Send push notification via FCM
+        sendPushNotification(event, record);
+    }
+
+    // -------------------------------------------------------------------------
+    // FCM push dispatch
+    // -------------------------------------------------------------------------
+
+    private void sendPushNotification(NotificationEvent event, UserNotification record) {
+        if (firebaseMessaging == null) {
+            log.debug("FCM not configured — skipping push for recipient {}", event.getRecipientId());
+            return;
+        }
+
+        String deviceToken = lookupDeviceToken(event.getRecipientId());
+        if (deviceToken == null || deviceToken.isBlank()) {
+            log.debug("No FCM device token for recipient {} — skipping push", event.getRecipientId());
+            return;
+        }
+
+        String title = event.getTitle() != null ? event.getTitle() : event.getType().name();
+        String body  = event.getBody() != null ? event.getBody() : "";
+        Map<String, String> data = event.getData() != null ? event.getData() : Collections.emptyMap();
+
+        Message message = Message.builder()
+            .setToken(deviceToken)
+            .setNotification(Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build())
+            .putAllData(data)
+            .build();
+
+        try {
+            String messageId = firebaseMessaging.send(message);
+            record.setPushed(true);
+            notifRepo.save(record);
+            log.info("FCM push sent to {} — messageId={} type={}", event.getRecipientId(), messageId, event.getType());
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM push failed for recipient {} type={}: {}", event.getRecipientId(), event.getType(), e.getMessage());
+        }
+    }
+
+    private String lookupDeviceToken(java.util.UUID userId) {
+        // Device tokens are stored in Aerospike under notif_prefs:{userId} in the fcmToken bin.
+        // Clients register tokens via the /api/v1/users/{userId}/notifications/device-token endpoint.
+        Key key = new Key(NS, "notif_prefs:" + userId, userId.toString());
+        Record rec = aerospike.get(null, key, "fcmToken");
+        if (rec == null) return null;
+        return rec.getString("fcmToken");
     }
 
     // -------------------------------------------------------------------------

--- a/PlaylistService/Dockerfile
+++ b/PlaylistService/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8-jdk21-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN gradle build -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/PlaylistService/build.gradle
+++ b/PlaylistService/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '3.5.11'
+	id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.play.stream'
+version = '0.0.1-SNAPSHOT'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	// PostgreSQL — durable playlist storage
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'org.postgresql:postgresql'
+
+	// Kafka — publishes playlist.event messages
+	implementation 'org.springframework.kafka:spring-kafka'
+
+	// Jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+	// OpenAPI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/PlaylistService/settings.gradle
+++ b/PlaylistService/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'PlaylistService'

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/PlaylistServiceApplication.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/PlaylistServiceApplication.java
@@ -1,0 +1,14 @@
+package com.play.stream.Starjams.PlaylistService;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+@SpringBootApplication
+@EnableDiscoveryClient
+public class PlaylistServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PlaylistServiceApplication.class, args);
+    }
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/config/KafkaTopics.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/config/KafkaTopics.java
@@ -1,0 +1,7 @@
+package com.play.stream.Starjams.PlaylistService.config;
+
+public final class KafkaTopics {
+    public static final String PLAYLIST_EVENT = "playlist.event";
+
+    private KafkaTopics() {}
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/controller/PlaylistController.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/controller/PlaylistController.java
@@ -1,0 +1,62 @@
+package com.play.stream.Starjams.PlaylistService.controller;
+
+import com.play.stream.Starjams.PlaylistService.dto.AddTrackRequest;
+import com.play.stream.Starjams.PlaylistService.dto.CreatePlaylistRequest;
+import com.play.stream.Starjams.PlaylistService.dto.PlaylistResponse;
+import com.play.stream.Starjams.PlaylistService.service.PlaylistService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/playlists")
+public class PlaylistController {
+
+    private final PlaylistService playlistService;
+
+    public PlaylistController(PlaylistService playlistService) {
+        this.playlistService = playlistService;
+    }
+
+    @PostMapping
+    public ResponseEntity<PlaylistResponse> createPlaylist(
+            @RequestParam String ownerId,
+            @Valid @RequestBody CreatePlaylistRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(playlistService.createPlaylist(ownerId, req));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PlaylistResponse> getPlaylist(@PathVariable UUID id) {
+        return ResponseEntity.ok(playlistService.getPlaylist(id));
+    }
+
+    @GetMapping("/user/{ownerId}")
+    public ResponseEntity<List<PlaylistResponse>> getUserPlaylists(@PathVariable String ownerId) {
+        return ResponseEntity.ok(playlistService.getUserPlaylists(ownerId));
+    }
+
+    @PostMapping("/{id}/tracks")
+    public ResponseEntity<PlaylistResponse> addTrack(
+            @PathVariable UUID id,
+            @Valid @RequestBody AddTrackRequest req) {
+        return ResponseEntity.ok(playlistService.addTrack(id, req));
+    }
+
+    @DeleteMapping("/{id}/tracks/{trackId}")
+    public ResponseEntity<PlaylistResponse> removeTrack(
+            @PathVariable UUID id,
+            @PathVariable String trackId) {
+        return ResponseEntity.ok(playlistService.removeTrack(id, trackId));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePlaylist(@PathVariable UUID id) {
+        playlistService.deletePlaylist(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/dto/AddTrackRequest.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/dto/AddTrackRequest.java
@@ -1,0 +1,12 @@
+package com.play.stream.Starjams.PlaylistService.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class AddTrackRequest {
+
+    @NotBlank
+    private String trackId;
+
+    public String getTrackId() { return trackId; }
+    public void setTrackId(String trackId) { this.trackId = trackId; }
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/dto/CreatePlaylistRequest.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/dto/CreatePlaylistRequest.java
@@ -1,0 +1,25 @@
+package com.play.stream.Starjams.PlaylistService.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class CreatePlaylistRequest {
+
+    @NotBlank
+    @Size(max = 200)
+    private String title;
+
+    @Size(max = 1000)
+    private String description;
+
+    private boolean isPublic = true;
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public boolean isPublic() { return isPublic; }
+    public void setPublic(boolean aPublic) { isPublic = aPublic; }
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/dto/PlaylistResponse.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/dto/PlaylistResponse.java
@@ -1,0 +1,41 @@
+package com.play.stream.Starjams.PlaylistService.dto;
+
+import com.play.stream.Starjams.PlaylistService.model.Playlist;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public class PlaylistResponse {
+
+    private UUID id;
+    private String ownerId;
+    private String title;
+    private String description;
+    private List<String> trackIds;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private boolean isPublic;
+
+    public static PlaylistResponse from(Playlist p) {
+        PlaylistResponse r = new PlaylistResponse();
+        r.id          = p.getId();
+        r.ownerId     = p.getOwnerId();
+        r.title       = p.getTitle();
+        r.description = p.getDescription();
+        r.trackIds    = p.getTrackIds();
+        r.createdAt   = p.getCreatedAt();
+        r.updatedAt   = p.getUpdatedAt();
+        r.isPublic    = p.isPublic();
+        return r;
+    }
+
+    public UUID getId() { return id; }
+    public String getOwnerId() { return ownerId; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public List<String> getTrackIds() { return trackIds; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+    public boolean isPublic() { return isPublic; }
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/model/Playlist.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/model/Playlist.java
@@ -1,0 +1,66 @@
+package com.play.stream.Starjams.PlaylistService.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "playlists")
+public class Playlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "owner_id", nullable = false)
+    private String ownerId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @ElementCollection
+    @CollectionTable(name = "playlist_tracks", joinColumns = @JoinColumn(name = "playlist_id"))
+    @Column(name = "track_id")
+    @OrderColumn(name = "position")
+    private List<String> trackIds = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic;
+
+    public Playlist() {}
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    public String getOwnerId() { return ownerId; }
+    public void setOwnerId(String ownerId) { this.ownerId = ownerId; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public List<String> getTrackIds() { return trackIds; }
+    public void setTrackIds(List<String> trackIds) { this.trackIds = trackIds; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+
+    public boolean isPublic() { return isPublic; }
+    public void setPublic(boolean aPublic) { isPublic = aPublic; }
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/repository/PlaylistRepository.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/repository/PlaylistRepository.java
@@ -1,0 +1,12 @@
+package com.play.stream.Starjams.PlaylistService.repository;
+
+import com.play.stream.Starjams.PlaylistService.model.Playlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, UUID> {
+
+    List<Playlist> findByOwnerIdOrderByCreatedAtDesc(String ownerId);
+}

--- a/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/service/PlaylistService.java
+++ b/PlaylistService/src/main/java/com/play/stream/Starjams/PlaylistService/service/PlaylistService.java
@@ -1,0 +1,122 @@
+package com.play.stream.Starjams.PlaylistService.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.play.stream.Starjams.PlaylistService.config.KafkaTopics;
+import com.play.stream.Starjams.PlaylistService.dto.AddTrackRequest;
+import com.play.stream.Starjams.PlaylistService.dto.CreatePlaylistRequest;
+import com.play.stream.Starjams.PlaylistService.dto.PlaylistResponse;
+import com.play.stream.Starjams.PlaylistService.model.Playlist;
+import com.play.stream.Starjams.PlaylistService.repository.PlaylistRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class PlaylistService {
+
+    private static final Logger log = LoggerFactory.getLogger(PlaylistService.class);
+
+    private final PlaylistRepository playlistRepo;
+    private final KafkaTemplate<String, String> kafka;
+    private final ObjectMapper objectMapper;
+
+    public PlaylistService(PlaylistRepository playlistRepo,
+                           KafkaTemplate<String, String> kafka,
+                           ObjectMapper objectMapper) {
+        this.playlistRepo = playlistRepo;
+        this.kafka        = kafka;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public PlaylistResponse createPlaylist(String ownerId, CreatePlaylistRequest req) {
+        Playlist playlist = new Playlist();
+        playlist.setOwnerId(ownerId);
+        playlist.setTitle(req.getTitle());
+        playlist.setDescription(req.getDescription());
+        playlist.setPublic(req.isPublic());
+        Instant now = Instant.now();
+        playlist.setCreatedAt(now);
+        playlist.setUpdatedAt(now);
+
+        Playlist saved = playlistRepo.save(playlist);
+        publishEvent(saved.getId(), ownerId, "PLAYLIST_CREATED");
+        log.info("Created playlist {} for owner {}", saved.getId(), ownerId);
+        return PlaylistResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public PlaylistResponse getPlaylist(UUID id) {
+        return playlistRepo.findById(id)
+            .map(PlaylistResponse::from)
+            .orElseThrow(() -> new NoSuchElementException("Playlist not found: " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaylistResponse> getUserPlaylists(String ownerId) {
+        return playlistRepo.findByOwnerIdOrderByCreatedAtDesc(ownerId)
+            .stream()
+            .map(PlaylistResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public PlaylistResponse addTrack(UUID playlistId, AddTrackRequest req) {
+        Playlist playlist = findOrThrow(playlistId);
+        if (!playlist.getTrackIds().contains(req.getTrackId())) {
+            playlist.getTrackIds().add(req.getTrackId());
+        }
+        playlist.setUpdatedAt(Instant.now());
+        Playlist saved = playlistRepo.save(playlist);
+        publishEvent(saved.getId(), saved.getOwnerId(), "TRACK_ADDED");
+        return PlaylistResponse.from(saved);
+    }
+
+    @Transactional
+    public PlaylistResponse removeTrack(UUID playlistId, String trackId) {
+        Playlist playlist = findOrThrow(playlistId);
+        playlist.getTrackIds().remove(trackId);
+        playlist.setUpdatedAt(Instant.now());
+        Playlist saved = playlistRepo.save(playlist);
+        publishEvent(saved.getId(), saved.getOwnerId(), "TRACK_REMOVED");
+        return PlaylistResponse.from(saved);
+    }
+
+    @Transactional
+    public void deletePlaylist(UUID playlistId) {
+        Playlist playlist = findOrThrow(playlistId);
+        publishEvent(playlist.getId(), playlist.getOwnerId(), "PLAYLIST_DELETED");
+        playlistRepo.deleteById(playlistId);
+        log.info("Deleted playlist {}", playlistId);
+    }
+
+    // -------------------------------------------------------------------------
+
+    private Playlist findOrThrow(UUID id) {
+        return playlistRepo.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Playlist not found: " + id));
+    }
+
+    private void publishEvent(UUID playlistId, String ownerId, String eventType) {
+        try {
+            Map<String, String> payload = Map.of(
+                "playlistId", playlistId.toString(),
+                "ownerId",    ownerId,
+                "eventType",  eventType
+            );
+            String json = objectMapper.writeValueAsString(payload);
+            kafka.send(KafkaTopics.PLAYLIST_EVENT, playlistId.toString(), json);
+        } catch (Exception e) {
+            log.warn("Failed to publish playlist.event for playlist {}: {}", playlistId, e.getMessage());
+        }
+    }
+}

--- a/PlaylistService/src/main/resources/application.yml
+++ b/PlaylistService/src/main/resources/application.yml
@@ -1,0 +1,35 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: playlist-service
+
+  datasource:
+    url: ${POSTGRES_URL:jdbc:postgresql://localhost:5432/fetio}
+    username: ${POSTGRES_USER:fetio}
+    password: ${POSTGRES_PASSWORD:fetio}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_URL:http://localhost:8761/eureka/}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,128 @@
 version: '3.8'
 
 services:
+
+  # ── Service Discovery ─────────────────────────────────────────────────────
+  eureka:
+    image: springcloud/eureka
+    ports:
+      - "8761:8761"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8761/actuator/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  # ── Zookeeper (Kafka dependency) ──────────────────────────────────────────
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc localhost 2181 | grep imok"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # ── Kafka ─────────────────────────────────────────────────────────────────
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  # ── Redis ─────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   gateway-service:
     build: ./GatewayService
     ports:
       - "8080:8080"
+    depends_on:
+      eureka:
+        condition: service_healthy
+
   payment-service:
     build: ./PaymentService
     ports:
       - "8081:8080"
+    depends_on:
+      eureka:
+        condition: service_healthy
+
   music-service:
     build: ./MusicService
     ports:
       - "8082:8080"
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+    depends_on:
+      eureka:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+
   admin-service:
     build: ./AdminService
     ports:
       - "8083:8080"
+    depends_on:
+      eureka:
+        condition: service_healthy
+
   user-service:
     build: ./UserService
     ports:
-      - "8084:8080"      
+      - "8084:8080"
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      eureka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
   like-service:
     build: ./LikeService
     ports:
       - "8086:8080"
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+    depends_on:
+      eureka:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+
   upload-service:
     build: ./UploadService
     ports:
@@ -32,9 +130,14 @@ services:
     environment:
       - SPRING_DATA_CASSANDRA_CONTACT_POINTS=scylla
       - SPRING_DATA_CASSANDRA_KEYSPACE_NAME=starjamz_uploads
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
     depends_on:
       scylla-init:
         condition: service_completed_successfully
+      eureka:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
 
   notification-service:
     build: ./NotificationService
@@ -48,8 +151,14 @@ services:
       - POSTGRES_PASSWORD=fetio
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
     depends_on:
-      - postgres
-      - aerospike
+      postgres:
+        condition: service_healthy
+      aerospike:
+        condition: service_started
+      kafka:
+        condition: service_healthy
+      eureka:
+        condition: service_healthy
 
   # ── Media Ingress Service ─────────────────────────────────────────────────────
   media-ingress-service:
@@ -70,8 +179,14 @@ services:
       - ADMIN_USERNAME=admin
       - ADMIN_PASSWORD=changeme
     depends_on:
-      - postgres
-      - aerospike
+      postgres:
+        condition: service_healthy
+      aerospike:
+        condition: service_started
+      kafka:
+        condition: service_healthy
+      eureka:
+        condition: service_healthy
 
   # ── Feed Service overrides (Aerospike + PostgreSQL) ───────────────────────────
   feed-service:
@@ -85,9 +200,37 @@ services:
       - POSTGRES_USER=fetio
       - POSTGRES_PASSWORD=fetio
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
     depends_on:
-      - postgres
-      - aerospike
+      postgres:
+        condition: service_healthy
+      aerospike:
+        condition: service_started
+      kafka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      eureka:
+        condition: service_healthy
+
+  # ── Playlist Service ──────────────────────────────────────────────────────
+  playlist-service:
+    build: ./PlaylistService
+    ports:
+      - "8090:8080"
+    environment:
+      - POSTGRES_URL=jdbc:postgresql://postgres:5432/fetio
+      - POSTGRES_USER=fetio
+      - POSTGRES_PASSWORD=fetio
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      eureka:
+        condition: service_healthy
 
   # ── Aerospike ─────────────────────────────────────────────────────────────────
   aerospike:
@@ -120,7 +263,7 @@ services:
     ports:
       - "3000:3000"
 
-  # ── ScyllaDB ─────────────────────────────────────────────────────────────────
+  # ── ScyllaDB ─────────────────────────────────────────────────────────────
   scylla:
     image: scylladb/scylla:5.4
     ports:


### PR DESCRIPTION
Doing 13 other things at once and decided to do a bug sweep. There were a few loose ends that needed to be tightened such as: 
1. Both java-version entries in .github/workflows/gradle.yml updated to '21', 
2. docker-compose.yml gains eureka, zookeeper, kafka, redis, playlist-service; all backend services get depends_on + corrected Kafka/Redis env vars, 
3. Full Spring Boot service from scratch — Playlist entity, PlaylistRepository, PlaylistService (with Kafka playlist.event publishing), PlaylistController at /api/v1/playlists, build.gradle, Dockerfile, application.yml
4. FirebaseConfig initialises Firebase Admin SDK (gracefully disabled when FIREBASE_CREDENTIALS_PATH is unset); NotificationDeliveryService now builds and sends a real Message via FirebaseMessaging, looks up device tokens from Aerospike notif_prefs:{userId} bin fcmToken, handles FirebaseMessagingException without propagating, 
5. blendPopularContent() now constructs synthetic FeedEvent objects from trending IDs, hydrates counters from Aerospike, deduplicates against existing personal feed, and interleaves popular items at every Nth slot based on the blend ratio
6. flushRoyaltiesToPostgres() scans Aerospike stem_session_royalties, batch-inserts into StemRoyaltyLedger via saveAll(), then deletes the flushed records; failure leaves Aerospike intact for the next run