### PR TITLE
feat(frontend): build feed UI with Electric Lime / Deep Violet palette

### DIFF
--- a/Frontend/starjamz/components/FeedCard.tsx
+++ b/Frontend/starjamz/components/FeedCard.tsx
@@ -1,0 +1,589 @@
+import React, { useState } from "react";
+
+// ─── Types mirroring FeedService models ──────────────────────────────────────
+
+export type EventType =
+  | "TRACK_POSTED"
+  | "TRACK_LIKED"
+  | "TRACK_PLAYED"
+  | "TRACK_REPOSTED"
+  | "TRACK_REMIXED"
+  | "VIDEO_POSTED"
+  | "VIDEO_LIKED"
+  | "VIDEO_VIEWED"
+  | "ARTIST_FOLLOWED"
+  | "PLAYLIST_CREATED"
+  | "PLAYLIST_LIKED"
+  | "PLAYLIST_TRACK_ADDED"
+  | "PLAYLIST_COLLABORATIVE_JOINED"
+  | "PLAYLIST_SHARED"
+  | "LIVESTREAM_STARTED_AUDIO"
+  | "LIVESTREAM_STARTED_VIDEO"
+  | "LIVESTREAM_ENDED"
+  | "LIVESTREAM_CLIPPED"
+  | "DIGEST"
+  | "TRENDING_USER"
+  | "POPULAR_TRACK"
+  | "POPULAR_VIDEO"
+  | "POPULAR_PLAYLIST"
+  | "POPULAR_LIVESTREAM";
+
+export interface CollaboratorRef {
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+export interface FeedEvent {
+  cardType?: string;
+  eventId: string;
+  eventType: EventType;
+  actorId: string;
+  actorDisplayName: string;
+  actorAvatarUrl: string | null;
+  // track
+  trackId?: string;
+  trackTitle?: string;
+  trackDuration?: number;
+  coverArtUrl?: string;
+  audioStreamUrl?: string;
+  genre?: string[];
+  mood?: string;
+  // video
+  videoId?: string;
+  videoTitle?: string;
+  videoThumbnailUrl?: string;
+  videoStreamUrl?: string;
+  // counters
+  playCount?: number;
+  likeCount?: number;
+  repostCount?: number;
+  commentCount?: number;
+  // timestamps
+  postedAt?: string;
+  // viral
+  isNew?: boolean;
+  isBuzzing?: boolean;
+  // gift-to-unlock
+  isLocked?: boolean;
+  giftThreshold?: number;
+  giftProgress?: number;
+  // repost
+  originalActorId?: string;
+  originalActorDisplayName?: string;
+  repostCommentText?: string;
+  // collaborators
+  collaborators?: CollaboratorRef[];
+  // livestream
+  streamId?: string;
+  isLive?: boolean;
+  viewerCount?: number;
+  streamThumbnailUrl?: string;
+  // playlist
+  playlistId?: string;
+  playlistTitle?: string;
+  playlistCoverMosaic?: string[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function fmtCount(n: number | undefined): string {
+  if (!n) return "0";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000)     return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function fmtDuration(secs: number | undefined): string {
+  if (!secs) return "0:00";
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function timeAgo(isoString: string | undefined): string {
+  if (!isoString) return "";
+  const diff = Date.now() - new Date(isoString).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1)  return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24)  return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function Avatar({
+  url,
+  name,
+  size = 40,
+}: {
+  url: string | null;
+  name: string;
+  size?: number;
+}) {
+  const initials = name
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+
+  return url ? (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={name}
+      width={size}
+      height={size}
+      className="rounded-full object-cover flex-shrink-0"
+      style={{ width: size, height: size }}
+    />
+  ) : (
+    <div
+      className="rounded-full flex items-center justify-center bg-surface-subtle text-ink-muted font-semibold flex-shrink-0"
+      style={{ width: size, height: size, fontSize: size * 0.38 }}
+    >
+      {initials}
+    </div>
+  );
+}
+
+function WaveformVisualiser({ bars = 28 }: { bars?: number }) {
+  return (
+    <div className="flex items-center gap-px h-8 overflow-hidden">
+      {Array.from({ length: bars }).map((_, i) => (
+        <div
+          key={i}
+          className="waveform-bar"
+          style={{
+            animationDelay: `${(i * 0.05) % 1.2}s`,
+            height: `${30 + Math.sin(i * 0.9) * 20 + Math.random() * 20}%`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StatRow({ event }: { event: FeedEvent }) {
+  const [liked, setLiked] = useState(false);
+  const [reposted, setReposted] = useState(false);
+
+  return (
+    <div className="flex items-center gap-5 mt-3 pt-3 border-t border-surface-divider">
+      <button
+        onClick={() => setLiked((v) => !v)}
+        className={`stat-pill ${liked ? "text-brand-300" : ""}`}
+        aria-label="Like"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill={liked ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2">
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+        </svg>
+        <span>{fmtCount((event.likeCount ?? 0) + (liked ? 1 : 0))}</span>
+      </button>
+
+      <button
+        onClick={() => setReposted((v) => !v)}
+        className={`stat-pill ${reposted ? "text-accent-300" : ""}`}
+        aria-label="Repost"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="17 1 21 5 17 9" />
+          <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+          <polyline points="7 23 3 19 7 15" />
+          <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+        </svg>
+        <span>{fmtCount((event.repostCount ?? 0) + (reposted ? 1 : 0))}</span>
+      </button>
+
+      <span className="stat-pill">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        <span>{fmtCount(event.commentCount)}</span>
+      </span>
+
+      <span className="stat-pill ml-auto">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polygon points="5 3 19 12 5 21 5 3" />
+        </svg>
+        <span>{fmtCount(event.playCount)}</span>
+      </span>
+    </div>
+  );
+}
+
+// ─── Card variants ────────────────────────────────────────────────────────────
+
+function TrackCard({ event }: { event: FeedEvent }) {
+  const [playing, setPlaying] = useState(false);
+  const isRepost = event.eventType === "TRACK_REPOSTED";
+
+  return (
+    <article className="card p-4 animate-slide-up">
+      {/* Repost context line */}
+      {isRepost && event.originalActorDisplayName && (
+        <div className="flex items-center gap-1.5 text-xs text-ink-muted mb-3">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="17 1 21 5 17 9" />
+            <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+            <polyline points="7 23 3 19 7 15" />
+            <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+          </svg>
+          <span>
+            <span className="text-ink-secondary font-medium">{event.actorDisplayName}</span>
+            {" reposted from "}
+            <span className="text-ink-secondary font-medium">{event.originalActorDisplayName}</span>
+          </span>
+        </div>
+      )}
+
+      {/* Actor row */}
+      <div className="flex items-center gap-3 mb-3">
+        <Avatar url={event.actorAvatarUrl} name={event.actorDisplayName} />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-ink-primary truncate">{event.actorDisplayName}</p>
+          <p className="text-xs text-ink-muted">{timeAgo(event.postedAt)}</p>
+        </div>
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {event.isBuzzing && <span className="badge-buzzing">⚡ Buzzing</span>}
+          {event.isNew    && <span className="badge-new">New</span>}
+        </div>
+      </div>
+
+      {/* Cover art + track info */}
+      <div className="flex gap-3">
+        <div className="relative flex-shrink-0">
+          {event.coverArtUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={event.coverArtUrl}
+              alt={event.trackTitle}
+              width={80}
+              height={80}
+              className="rounded-xl object-cover w-20 h-20"
+            />
+          ) : (
+            <div className="w-20 h-20 rounded-xl bg-surface-subtle flex items-center justify-center">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8A9966" strokeWidth="1.5">
+                <circle cx="12" cy="12" r="10" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            </div>
+          )}
+          {/* Play button overlay */}
+          <button
+            onClick={() => setPlaying((v) => !v)}
+            aria-label={playing ? "Pause" : "Play"}
+            className="absolute inset-0 rounded-xl flex items-center justify-center
+                       bg-surface-base/60 opacity-0 hover:opacity-100 transition-opacity"
+          >
+            <div className="w-8 h-8 rounded-full bg-brand-300 flex items-center justify-center shadow-lime-sm">
+              {playing ? (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="#080C04">
+                  <rect x="6" y="4" width="4" height="16" />
+                  <rect x="14" y="4" width="4" height="16" />
+                </svg>
+              ) : (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="#080C04">
+                  <polygon points="5 3 19 12 5 21 5 3" />
+                </svg>
+              )}
+            </div>
+          </button>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-ink-primary leading-snug mb-1 truncate">
+            {event.trackTitle ?? "Untitled Track"}
+          </h3>
+          {event.genre && event.genre.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-2">
+              {event.genre.slice(0, 3).map((g) => (
+                <span key={g} className="text-[10px] px-1.5 py-0.5 rounded-full border border-surface-border text-ink-muted">
+                  {g}
+                </span>
+              ))}
+              {event.mood && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-accent-700 text-accent-300">
+                  {event.mood}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Waveform / progress */}
+          <div className="relative">
+            {playing ? (
+              <WaveformVisualiser bars={32} />
+            ) : (
+              <div className="h-8 flex items-center">
+                <div className="flex-1 h-px bg-surface-border relative overflow-hidden">
+                  <div className="absolute inset-0 bg-waveform-gradient opacity-40 rounded-full" />
+                </div>
+              </div>
+            )}
+            <span className="absolute right-0 top-1/2 -translate-y-1/2 text-[10px] text-ink-disabled">
+              {fmtDuration(event.trackDuration)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Gift-to-unlock bar */}
+      {event.isLocked && event.giftThreshold !== undefined && (
+        <div className="mt-3 p-3 rounded-xl bg-surface-subtle border border-surface-border">
+          <div className="flex items-center justify-between text-xs mb-2">
+            <span className="text-ink-secondary font-medium">🎁 Gift to unlock full track</span>
+            <span className="text-brand-300 font-bold">
+              {event.giftProgress ?? 0} / {event.giftThreshold} gifts
+            </span>
+          </div>
+          <div className="gift-progress-bar">
+            <div
+              className="gift-progress-fill"
+              style={{ width: `${Math.min(100, ((event.giftProgress ?? 0) / event.giftThreshold!) * 100)}%` }}
+            />
+          </div>
+          <button className="btn-primary w-full mt-2 text-xs justify-center">
+            Send a Gift
+          </button>
+        </div>
+      )}
+
+      {/* Repost comment */}
+      {event.repostCommentText && (
+        <p className="mt-2 text-xs text-ink-secondary italic border-l-2 border-brand-700 pl-2">
+          &ldquo;{event.repostCommentText}&rdquo;
+        </p>
+      )}
+
+      {/* Collaborators */}
+      {event.collaborators && event.collaborators.length > 0 && (
+        <div className="flex items-center gap-1.5 mt-2 text-xs text-ink-muted">
+          <span>ft.</span>
+          {event.collaborators.map((c) => (
+            <span key={c.userId} className="flex items-center gap-1">
+              <Avatar url={c.avatarUrl} name={c.displayName} size={16} />
+              <span className="text-ink-secondary">{c.displayName}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <StatRow event={event} />
+    </article>
+  );
+}
+
+function LivestreamCard({ event }: { event: FeedEvent }) {
+  return (
+    <article className="card border-red-800/60 animate-slide-up overflow-hidden">
+      {/* Thumbnail */}
+      <div className="relative">
+        {event.streamThumbnailUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={event.streamThumbnailUrl}
+            alt="Livestream"
+            className="w-full h-40 object-cover"
+          />
+        ) : (
+          <div className="w-full h-40 bg-gradient-to-br from-surface-subtle to-surface-overlay flex items-center justify-center">
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#AAFF00" strokeWidth="1.5">
+              <circle cx="12" cy="12" r="10" />
+              <circle cx="12" cy="12" r="3" />
+              <line x1="12" y1="2" x2="12" y2="5" />
+              <line x1="12" y1="19" x2="12" y2="22" />
+              <line x1="2" y1="12" x2="5" y2="12" />
+              <line x1="19" y1="12" x2="22" y2="12" />
+            </svg>
+          </div>
+        )}
+        <div className="absolute top-2 left-2">
+          <span className="badge-live">
+            <span className="w-1.5 h-1.5 rounded-full bg-white animate-pulse" />
+            LIVE
+          </span>
+        </div>
+        {event.viewerCount !== undefined && event.viewerCount > 0 && (
+          <div className="absolute top-2 right-2 flex items-center gap-1 bg-surface-base/80 rounded-full px-2 py-0.5 text-xs text-ink-secondary backdrop-blur-sm">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+            {fmtCount(event.viewerCount)}
+          </div>
+        )}
+      </div>
+
+      <div className="p-4">
+        <div className="flex items-center gap-3">
+          <Avatar url={event.actorAvatarUrl} name={event.actorDisplayName} />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-ink-primary truncate">{event.actorDisplayName}</p>
+            <p className="text-xs text-ink-muted">is live now</p>
+          </div>
+        </div>
+        <button className="btn-primary w-full mt-3 justify-center">
+          Join Stream
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function DigestCard({ event }: { event: FeedEvent }) {
+  return (
+    <article className="card-featured p-4 animate-fade-in">
+      <div className="flex items-center gap-2 mb-3">
+        <div className="w-5 h-5 rounded-full bg-brand-gradient flex items-center justify-center">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="#080C04">
+            <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+          </svg>
+        </div>
+        <span className="text-xs font-bold text-brand-300 uppercase tracking-wider">Activity Digest</span>
+      </div>
+      <div className="flex items-center gap-3">
+        <Avatar url={event.actorAvatarUrl} name={event.actorDisplayName} />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-ink-primary">
+            <span className="text-brand-300">{event.actorDisplayName}</span>
+            {" had a busy session"}
+          </p>
+          <div className="flex items-center gap-3 mt-1 text-xs text-ink-muted">
+            {event.playCount !== undefined && event.playCount > 0 && (
+              <span>{fmtCount(event.playCount)} plays</span>
+            )}
+            {event.likeCount !== undefined && event.likeCount > 0 && (
+              <span>{fmtCount(event.likeCount)} likes</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function TrendingUserCard({ event }: { event: FeedEvent }) {
+  return (
+    <article className="card p-4 animate-fade-in">
+      <div className="flex items-center gap-2 mb-3">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#AAFF00" strokeWidth="2">
+          <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+          <polyline points="17 6 23 6 23 12" />
+        </svg>
+        <span className="text-xs font-bold text-brand-300 uppercase tracking-wider">Trending Artist</span>
+      </div>
+      <div className="flex items-center gap-3">
+        <Avatar url={event.actorAvatarUrl} name={event.actorDisplayName} size={48} />
+        <div className="flex-1 min-w-0">
+          <p className="text-base font-bold text-ink-primary truncate">{event.actorDisplayName}</p>
+          <p className="text-xs text-ink-muted mt-0.5">Growing fast in your network</p>
+        </div>
+        <button className="btn-ghost text-xs px-4 py-1.5">Follow</button>
+      </div>
+    </article>
+  );
+}
+
+function VideoCard({ event }: { event: FeedEvent }) {
+  return (
+    <article className="card overflow-hidden animate-slide-up">
+      <div className="relative">
+        {event.videoThumbnailUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={event.videoThumbnailUrl}
+            alt={event.videoTitle}
+            className="w-full h-44 object-cover"
+          />
+        ) : (
+          <div className="w-full h-44 bg-surface-subtle flex items-center justify-center">
+            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#8A9966" strokeWidth="1.5">
+              <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
+              <line x1="7" y1="2" x2="7" y2="22" />
+              <line x1="17" y1="2" x2="17" y2="22" />
+              <line x1="2" y1="12" x2="22" y2="12" />
+              <line x1="2" y1="7" x2="7" y2="7" />
+              <line x1="2" y1="17" x2="7" y2="17" />
+              <line x1="17" y1="17" x2="22" y2="17" />
+              <line x1="17" y1="7" x2="22" y2="7" />
+            </svg>
+          </div>
+        )}
+        <button
+          aria-label="Play video"
+          className="absolute inset-0 flex items-center justify-center
+                     bg-surface-base/40 hover:bg-surface-base/20 transition-colors"
+        >
+          <div className="w-12 h-12 rounded-full bg-brand-300/90 flex items-center justify-center shadow-lime-md">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="#080C04">
+              <polygon points="5 3 19 12 5 21 5 3" />
+            </svg>
+          </div>
+        </button>
+      </div>
+
+      <div className="p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Avatar url={event.actorAvatarUrl} name={event.actorDisplayName} size={24} />
+          <span className="text-xs text-ink-secondary font-medium">{event.actorDisplayName}</span>
+          <span className="text-xs text-ink-disabled ml-auto">{timeAgo(event.postedAt)}</span>
+        </div>
+        <h3 className="text-sm font-semibold text-ink-primary">
+          {event.videoTitle ?? "Untitled Video"}
+        </h3>
+        <StatRow event={event} />
+      </div>
+    </article>
+  );
+}
+
+function FollowCard({ event }: { event: FeedEvent }) {
+  return (
+    <article className="card p-4 animate-fade-in">
+      <div className="flex items-center gap-3">
+        <Avatar url={event.actorAvatarUrl} name={event.actorDisplayName} size={40} />
+        <div className="flex-1 min-w-0 text-sm text-ink-secondary">
+          <span className="font-semibold text-ink-primary">{event.actorDisplayName}</span>
+          {" started following someone in your network"}
+        </div>
+        <span className="text-xs text-ink-disabled">{timeAgo(event.postedAt)}</span>
+      </div>
+    </article>
+  );
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+interface FeedCardProps {
+  event: FeedEvent;
+}
+
+export default function FeedCard({ event }: FeedCardProps) {
+  const { eventType } = event;
+
+  if (eventType === "LIVESTREAM_STARTED_AUDIO" || eventType === "LIVESTREAM_STARTED_VIDEO") {
+    return <LivestreamCard event={event} />;
+  }
+  if (eventType === "DIGEST") {
+    return <DigestCard event={event} />;
+  }
+  if (eventType === "TRENDING_USER") {
+    return <TrendingUserCard event={event} />;
+  }
+  if (eventType === "VIDEO_POSTED" || eventType === "VIDEO_LIKED" || eventType === "POPULAR_VIDEO") {
+    return <VideoCard event={event} />;
+  }
+  if (eventType === "ARTIST_FOLLOWED") {
+    return <FollowCard event={event} />;
+  }
+
+  // Default: track-based card (TRACK_POSTED, TRACK_REPOSTED, TRACK_LIKED, etc.)
+  return <TrackCard event={event} />;
+}

--- a/Frontend/starjamz/pages/feed.tsx
+++ b/Frontend/starjamz/pages/feed.tsx
@@ -1,0 +1,448 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import type { NextPage, GetServerSideProps } from "next";
+import Head from "next/head";
+import FeedCard, { FeedEvent } from "@/components/FeedCard";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const GATEWAY_URL = process.env.NEXT_PUBLIC_GATEWAY_URL ?? "http://localhost:8080";
+const PAGE_SIZE = 20;
+
+// ─── Mock data — shown when the backend is unreachable ────────────────────────
+
+const MOCK_EVENTS: FeedEvent[] = [
+  {
+    eventId: "1",
+    eventType: "TRACK_POSTED",
+    actorId: "u1",
+    actorDisplayName: "Solara Beats",
+    actorAvatarUrl: null,
+    trackId: "t1",
+    trackTitle: "Midnight Cascade (ft. Nova)",
+    trackDuration: 214,
+    coverArtUrl: null,
+    genre: ["Electronic", "Ambient"],
+    mood: "Dreamy",
+    playCount: 14820,
+    likeCount: 1043,
+    repostCount: 312,
+    commentCount: 87,
+    postedAt: new Date(Date.now() - 25 * 60_000).toISOString(),
+    isNew: true,
+    isBuzzing: true,
+    collaborators: [
+      { userId: "u5", displayName: "Nova", avatarUrl: null },
+    ],
+  },
+  {
+    eventId: "2",
+    eventType: "LIVESTREAM_STARTED_VIDEO",
+    actorId: "u2",
+    actorDisplayName: "DJ Rëal",
+    actorAvatarUrl: null,
+    streamId: "s1",
+    isLive: true,
+    viewerCount: 3210,
+    streamThumbnailUrl: null,
+    postedAt: new Date(Date.now() - 8 * 60_000).toISOString(),
+  },
+  {
+    eventId: "3",
+    eventType: "TRACK_REPOSTED",
+    actorId: "u3",
+    actorDisplayName: "Kira Vox",
+    actorAvatarUrl: null,
+    trackId: "t2",
+    trackTitle: "Golden Hour Loop",
+    trackDuration: 178,
+    coverArtUrl: null,
+    genre: ["Lo-fi", "Chill"],
+    playCount: 5400,
+    likeCount: 320,
+    repostCount: 95,
+    commentCount: 22,
+    postedAt: new Date(Date.now() - 2 * 3600_000).toISOString(),
+    originalActorDisplayName: "Lux Taito",
+    repostCommentText: "This loop is pure therapy. Had it on repeat all afternoon.",
+  },
+  {
+    eventId: "4",
+    eventType: "TRACK_POSTED",
+    actorId: "u4",
+    actorDisplayName: "Neon Prophecy",
+    actorAvatarUrl: null,
+    trackId: "t3",
+    trackTitle: "Violet Protocol",
+    trackDuration: 257,
+    coverArtUrl: null,
+    genre: ["Synthwave", "Dark"],
+    mood: "Intense",
+    playCount: 890,
+    likeCount: 74,
+    repostCount: 18,
+    commentCount: 9,
+    postedAt: new Date(Date.now() - 5 * 3600_000).toISOString(),
+    isLocked: true,
+    giftThreshold: 5,
+    giftProgress: 3,
+  },
+  {
+    eventId: "5",
+    eventType: "TRENDING_USER",
+    actorId: "u5",
+    actorDisplayName: "Wren Solis",
+    actorAvatarUrl: null,
+    postedAt: new Date(Date.now() - 1 * 3600_000).toISOString(),
+  },
+  {
+    eventId: "6",
+    eventType: "VIDEO_POSTED",
+    actorId: "u6",
+    actorDisplayName: "Studio Session",
+    actorAvatarUrl: null,
+    videoId: "v1",
+    videoTitle: "Making a Beat from Scratch — full session",
+    videoThumbnailUrl: null,
+    playCount: 7200,
+    likeCount: 541,
+    repostCount: 88,
+    commentCount: 130,
+    postedAt: new Date(Date.now() - 12 * 3600_000).toISOString(),
+  },
+  {
+    eventId: "7",
+    eventType: "DIGEST",
+    actorId: "u7",
+    actorDisplayName: "Bass Theory",
+    actorAvatarUrl: null,
+    playCount: 42000,
+    likeCount: 3100,
+    postedAt: new Date(Date.now() - 3 * 3600_000).toISOString(),
+  },
+  {
+    eventId: "8",
+    eventType: "TRACK_REMIXED",
+    actorId: "u8",
+    actorDisplayName: "Pixel Drift",
+    actorAvatarUrl: null,
+    trackId: "t4",
+    trackTitle: "Aurora (Pixel Drift Remix)",
+    trackDuration: 198,
+    coverArtUrl: null,
+    genre: ["House", "Electronic"],
+    mood: "Uplifting",
+    playCount: 2100,
+    likeCount: 184,
+    repostCount: 46,
+    commentCount: 31,
+    postedAt: new Date(Date.now() - 7 * 3600_000).toISOString(),
+    isNew: true,
+    originalActorDisplayName: "Solara Beats",
+  },
+];
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface FeedPage {
+  items: FeedEvent[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+// ─── Data fetching ────────────────────────────────────────────────────────────
+
+async function fetchFeedPage(
+  userId: string,
+  cursor: string | null
+): Promise<FeedPage> {
+  const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (cursor) params.set("cursor", cursor);
+
+  const res = await fetch(
+    `${GATEWAY_URL}/feed/api/v1/users/${userId}/feed?${params.toString()}`
+  );
+
+  if (!res.ok) throw new Error(`Feed API ${res.status}`);
+  return res.json() as Promise<FeedPage>;
+}
+
+// ─── Skeleton card ────────────────────────────────────────────────────────────
+
+function SkeletonCard() {
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="skeleton w-10 h-10 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <div className="skeleton h-3 w-32 rounded" />
+          <div className="skeleton h-2 w-20 rounded" />
+        </div>
+      </div>
+      <div className="flex gap-3">
+        <div className="skeleton w-20 h-20 rounded-xl" />
+        <div className="flex-1 space-y-2 pt-1">
+          <div className="skeleton h-3 w-3/4 rounded" />
+          <div className="skeleton h-2 w-1/2 rounded" />
+          <div className="skeleton h-8 w-full rounded mt-2" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Nav bar ──────────────────────────────────────────────────────────────────
+
+function NavBar({ activeTab, onTab }: { activeTab: string; onTab: (t: string) => void }) {
+  const tabs = ["For You", "Following", "Trending", "Live"];
+
+  return (
+    <nav className="sticky top-0 z-20 bg-surface-base/80 backdrop-blur-md border-b border-surface-divider">
+      <div className="max-w-xl mx-auto px-4 flex items-center justify-between h-14">
+        {/* Logo */}
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-full bg-brand-gradient shadow-lime-sm" />
+          <span className="font-bold text-ink-primary tracking-tight">starjamz</span>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex items-center gap-1">
+          {tabs.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => onTab(tab)}
+              className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
+                activeTab === tab
+                  ? "bg-brand-300 text-surface-base shadow-lime-sm"
+                  : "text-ink-muted hover:text-ink-secondary"
+              }`}
+            >
+              {tab === "Live" ? (
+                <span className="flex items-center gap-1">
+                  <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />
+                  Live
+                </span>
+              ) : tab}
+            </button>
+          ))}
+        </div>
+
+        {/* Profile avatar placeholder */}
+        <button aria-label="Profile" className="w-8 h-8 rounded-full bg-surface-subtle border border-surface-border flex items-center justify-center text-xs text-ink-muted">
+          U
+        </button>
+      </div>
+    </nav>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+interface FeedPageProps {
+  userId: string;
+}
+
+const FeedPage: NextPage<FeedPageProps> = ({ userId }) => {
+  const [activeTab, setActiveTab] = useState("For You");
+  const [events, setEvents] = useState<FeedEvent[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [useMock, setUseMock] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const initialLoad = useRef(false);
+
+  const loadFirst = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const page = await fetchFeedPage(userId, null);
+      setEvents(page.items);
+      setCursor(page.nextCursor);
+      setHasMore(page.hasMore);
+    } catch {
+      // Backend unavailable — fall back to mock data
+      setEvents(MOCK_EVENTS);
+      setHasMore(false);
+      setCursor(null);
+      setUseMock(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore || !cursor) return;
+    setLoadingMore(true);
+    try {
+      const page = await fetchFeedPage(userId, cursor);
+      setEvents((prev) => [...prev, ...page.items]);
+      setCursor(page.nextCursor);
+      setHasMore(page.hasMore);
+    } catch (err) {
+      setError("Failed to load more posts.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [userId, cursor, hasMore, loadingMore]);
+
+  useEffect(() => {
+    if (initialLoad.current) return;
+    initialLoad.current = true;
+    loadFirst();
+  }, [loadFirst]);
+
+  // Reload when tab changes (for demo purposes the mock data stays the same)
+  useEffect(() => {
+    initialLoad.current = false;
+    setEvents([]);
+    setCursor(null);
+    setHasMore(true);
+    setUseMock(false);
+    initialLoad.current = false;
+    loadFirst();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
+
+  return (
+    <>
+      <Head>
+        <title>Feed — Starjamz</title>
+        <meta name="description" content="Your personalised music feed" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+
+      <div className="min-h-screen bg-surface-base bg-lime-glow">
+        <NavBar activeTab={activeTab} onTab={setActiveTab} />
+
+        <main className="max-w-xl mx-auto px-4 py-6 space-y-4">
+          {/* Mock data notice */}
+          {useMock && (
+            <div className="rounded-xl border border-brand-700 bg-surface-subtle px-4 py-3 flex items-center gap-3 text-xs text-ink-muted animate-fade-in">
+              <div className="w-1.5 h-1.5 rounded-full bg-brand-300 flex-shrink-0" />
+              <span>
+                GatewayService unavailable — showing preview data.{" "}
+                <span className="text-brand-300">Connect the backend to see live feed.</span>
+              </span>
+            </div>
+          )}
+
+          {/* Feed header */}
+          <div className="flex items-center justify-between">
+            <h1 className="text-lg font-bold text-ink-primary">
+              {activeTab === "For You" ? (
+                <>Your <span className="text-brand-gradient">Feed</span></>
+              ) : (
+                activeTab
+              )}
+            </h1>
+            <button
+              onClick={loadFirst}
+              disabled={loading}
+              className="text-xs text-ink-muted hover:text-brand-300 transition-colors disabled:opacity-50 flex items-center gap-1"
+              aria-label="Refresh feed"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className={loading ? "animate-spin" : ""}
+              >
+                <polyline points="23 4 23 10 17 10" />
+                <polyline points="1 20 1 14 7 14" />
+                <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+              </svg>
+              Refresh
+            </button>
+          </div>
+
+          {/* Skeleton loading state */}
+          {loading && (
+            <div className="space-y-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <SkeletonCard key={i} />
+              ))}
+            </div>
+          )}
+
+          {/* Feed cards */}
+          {!loading && events.length > 0 && (
+            <div className="space-y-4">
+              {events.map((event) => (
+                <FeedCard key={event.eventId} event={event} />
+              ))}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!loading && events.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <div className="w-16 h-16 rounded-full bg-surface-subtle flex items-center justify-center mb-4">
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#3A4D1C" strokeWidth="1.5">
+                  <circle cx="12" cy="12" r="10" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </div>
+              <p className="text-ink-secondary font-medium">Nothing here yet</p>
+              <p className="text-ink-muted text-sm mt-1">Follow some artists to fill your feed.</p>
+            </div>
+          )}
+
+          {/* Load more */}
+          {!loading && hasMore && events.length > 0 && (
+            <div className="flex justify-center pt-2">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="btn-ghost text-sm"
+              >
+                {loadingMore ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                    </svg>
+                    Loading…
+                  </span>
+                ) : (
+                  "Load more"
+                )}
+              </button>
+            </div>
+          )}
+
+          {/* End of feed */}
+          {!loading && !hasMore && events.length > 0 && (
+            <div className="text-center py-8">
+              <div className="inline-flex items-center gap-2 text-xs text-ink-disabled">
+                <div className="h-px w-12 bg-surface-border" />
+                You&apos;re all caught up
+                <div className="h-px w-12 bg-surface-border" />
+              </div>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <p className="text-center text-xs text-red-400">{error}</p>
+          )}
+        </main>
+      </div>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<FeedPageProps> = async (ctx) => {
+  // In production this would come from the session / JWT.
+  // For now, accept userId as a query param or fall back to a placeholder.
+  const userId =
+    typeof ctx.query.userId === "string"
+      ? ctx.query.userId
+      : "00000000-0000-0000-0000-000000000001";
+
+  return { props: { userId } };
+};
+
+export default FeedPage;

--- a/Frontend/starjamz/styles/globals.css
+++ b/Frontend/starjamz/styles/globals.css
@@ -2,32 +2,163 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ─── CSS custom properties ──────────────────────────────────────────────── */
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+  --color-brand:   #AAFF00;
+  --color-accent:  #7700FF;
+  --color-surface: #080C04;
+  --color-ink:     #F0F5E0;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
+/* ─── Base reset ─────────────────────────────────────────────────────────── */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    background-color: #080C04;
+    color: #F0F5E0;
+    font-family: Inter, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Scrollbar styling */
+  ::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+  ::-webkit-scrollbar-track {
+    background: #111A06;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: #3A4D1C;
+    border-radius: 2px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: #AAFF00;
   }
 }
 
-body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+/* ─── Component layer ────────────────────────────────────────────────────── */
+@layer components {
+
+  /* Buttons */
+  .btn-primary {
+    @apply inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-semibold text-sm
+           bg-brand-300 text-surface-base
+           transition-all duration-150
+           hover:bg-brand-200 hover:shadow-lime-md
+           active:bg-brand-400 active:scale-95
+           disabled:bg-brand-700 disabled:text-ink-disabled disabled:cursor-not-allowed;
+  }
+
+  .btn-ghost {
+    @apply inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-semibold text-sm
+           bg-transparent border border-surface-border text-ink-secondary
+           transition-all duration-150
+           hover:border-brand-300 hover:text-brand-300
+           active:scale-95;
+  }
+
+  .btn-violet {
+    @apply inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-semibold text-sm
+           bg-accent-400 text-white
+           transition-all duration-150
+           hover:bg-accent-300 hover:shadow-violet-md
+           active:bg-accent-500 active:scale-95;
+  }
+
+  /* Cards */
+  .card {
+    @apply bg-surface-raised border border-surface-border rounded-2xl
+           transition-all duration-200
+           hover:border-surface-muted hover:bg-surface-overlay;
+  }
+
+  .card-featured {
+    @apply card border-brand-700 bg-gradient-to-br from-surface-raised to-surface-overlay;
+    background-image: linear-gradient(135deg, #111A06 0%, #1A2A0A 100%);
+  }
+
+  /* Waveform bars */
+  .waveform-bar {
+    @apply w-0.5 rounded-full bg-waveform-gradient origin-bottom;
+    animation: waveform 1.2s ease-in-out infinite alternate;
+  }
+
+  /* Text gradient (gradient text for headings) */
+  .text-brand-gradient {
+    background: linear-gradient(135deg, #AAFF00 0%, #7700FF 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  /* Glow utilities */
+  .glow-lime {
+    box-shadow: 0 0 20px rgba(170,255,0,0.45);
+  }
+  .glow-violet {
+    box-shadow: 0 0 20px rgba(119,0,255,0.55);
+  }
+
+  /* Live badge */
+  .badge-live {
+    @apply inline-flex items-center gap-1 px-2 py-0.5 rounded-full
+           bg-red-600 text-white text-xs font-bold uppercase tracking-wider;
+  }
+
+  /* Buzzing badge */
+  .badge-buzzing {
+    @apply inline-flex items-center gap-1 px-2 py-0.5 rounded-full
+           bg-brand-300 text-surface-base text-xs font-bold uppercase tracking-wider;
+  }
+
+  /* New / First-48 badge */
+  .badge-new {
+    @apply inline-flex items-center gap-1 px-2 py-0.5 rounded-full
+           bg-accent-400 text-white text-xs font-bold uppercase tracking-wider;
+  }
+
+  /* Stat pill */
+  .stat-pill {
+    @apply inline-flex items-center gap-1 text-xs text-ink-muted
+           hover:text-ink-secondary transition-colors cursor-pointer;
+  }
+
+  /* Feed skeleton */
+  .skeleton {
+    @apply animate-pulse rounded-lg bg-surface-subtle;
+  }
+
+  /* Progress bar (gift-to-unlock) */
+  .gift-progress-bar {
+    @apply h-1 rounded-full bg-surface-subtle overflow-hidden;
+  }
+  .gift-progress-fill {
+    @apply h-full rounded-full bg-brand-gradient transition-all duration-500;
+  }
 }
 
+/* ─── Utility layer ──────────────────────────────────────────────────────── */
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/Frontend/starjamz/tailwind.config.ts
+++ b/Frontend/starjamz/tailwind.config.ts
@@ -8,13 +8,97 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        // Electric Lime — primary brand accent (CTAs, waveforms, active states)
+        brand: {
+          50:  "#F4FFD6",
+          100: "#E8FF99",
+          200: "#CCFF55",
+          300: "#AAFF00", // primary
+          400: "#88CC00",
+          500: "#66AA00",
+          600: "#4D8000",
+          700: "#334D00",
+          800: "#1A2600",
+          900: "#0D1300",
+        },
+        // Electric Violet — complementary accent (gradients, highlights)
+        accent: {
+          100: "#DDB3FF",
+          200: "#BB66FF",
+          300: "#9944FF",
+          400: "#7700FF", // primary
+          500: "#5500CC",
+          600: "#3D0099",
+          700: "#280066",
+          800: "#140033",
+        },
+        // Dark green-tinted surfaces (dark-first music app aesthetic)
+        surface: {
+          base:    "#080C04",
+          raised:  "#111A06",
+          overlay: "#1A2A0A",
+          subtle:  "#222E10",
+          muted:   "#2E3D16",
+          border:  "#3A4D1C",
+          divider: "#2A3A12",
+        },
+        // Text hierarchy — off-white/cream against dark surfaces
+        ink: {
+          primary:   "#F0F5E0",
+          secondary: "#C8D4A0",
+          muted:     "#8A9966",
+          disabled:  "#526035",
+        },
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        "gradient-conic":  "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        // Brand gradient — hero sections, featured cards
+        "brand-gradient": "linear-gradient(135deg, #AAFF00 0%, #7700FF 100%)",
+        // Subtle radial lime glow for hero backgrounds
+        "lime-glow": "radial-gradient(ellipse 60% 40% at 50% 0%, rgba(170,255,0,0.18) 0%, transparent 70%)",
+        // Vertical lime for waveform / audio visualiser bars
+        "waveform-gradient": "linear-gradient(to top, #AAFF00, rgba(170,255,0,0.3))",
+      },
+      boxShadow: {
+        "lime-sm": "0 0 8px rgba(170,255,0,0.35)",
+        "lime-md": "0 0 20px rgba(170,255,0,0.45)",
+        "lime-lg": "0 0 40px rgba(170,255,0,0.35), 0 0 80px rgba(170,255,0,0.15)",
+        "violet-sm": "0 0 8px rgba(119,0,255,0.45)",
+        "violet-md": "0 0 20px rgba(119,0,255,0.55)",
+      },
+      animation: {
+        "pulse-lime": "pulse-lime 2s ease-in-out infinite",
+        "waveform":   "waveform 1.2s ease-in-out infinite alternate",
+        "slide-up":   "slide-up 0.3s ease-out",
+        "fade-in":    "fade-in 0.25s ease-out",
+      },
+      keyframes: {
+        "pulse-lime": {
+          "0%, 100%": { boxShadow: "0 0 8px rgba(170,255,0,0.35)" },
+          "50%":       { boxShadow: "0 0 24px rgba(170,255,0,0.7)" },
+        },
+        "waveform": {
+          "0%":   { transform: "scaleY(0.3)" },
+          "100%": { transform: "scaleY(1)" },
+        },
+        "slide-up": {
+          "0%":   { transform: "translateY(12px)", opacity: "0" },
+          "100%": { transform: "translateY(0)",    opacity: "1" },
+        },
+        "fade-in": {
+          "0%":   { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+      },
+      fontFamily: {
+        sans: ["Inter", "system-ui", "sans-serif"],
+        mono: ["JetBrains Mono", "Fira Code", "monospace"],
       },
     },
   },
   plugins: [],
 };
+
 export default config;


### PR DESCRIPTION
- Extends tailwind.config.ts with brand (lime), accent (violet), surface, and ink color scales plus waveform/glow animations and box-shadow utilities
- Rewrites globals.css with component classes: .btn-primary, .btn-ghost, .btn-violet, .card, .card-featured, .waveform-bar, .badge-live, .badge-buzzing, .badge-new, .gift-progress-bar, .skeleton, .glow-lime/violet
- Adds FeedCard component rendering all FeedService EventTypes: TrackCard (posted/reposted/remixed), LivestreamCard, DigestCard, TrendingUserCard, VideoCard, FollowCard — each uses the palette
- Adds pages/feed.tsx: cursor-paginated feed via GatewayService GET /feed/api/v1/users/{userId}/feed, falls back to mock preview data when backend is unreachable; includes sticky nav with For You / Following / Trending / Live tabs, skeleton loaders, waveform visualiser, stat row, gift-to-unlock progress bar, and end-of-feed state

https://claude.ai/code/session_01V1HqQXc7mV3Fxnik1AN74W